### PR TITLE
Perform a deep clone of Color object

### DIFF
--- a/src/SyHolloway/MrColor/Color.php
+++ b/src/SyHolloway/MrColor/Color.php
@@ -64,6 +64,13 @@ class Color
         $this->bulkUpdate($values);
     }
     
+    public function __clone()
+    {
+        $this->extensions = clone $this->extensions;
+        
+        $this->formats = clone $this->formats;
+    }
+    
     /**
      * When setting the colors, run it through the update function but allow access
      * 

--- a/src/SyHolloway/MrColor/ExtensionCollection.php
+++ b/src/SyHolloway/MrColor/ExtensionCollection.php
@@ -42,6 +42,17 @@ class ExtensionCollection
         $this->extensions = self::$defaults;
     }
 
+    public function __clone()
+    {
+        $tmp = $this->extensions;
+
+        $this->extensions = array();
+
+        foreach ($tmp as $extension) {
+            $this->extensions[] = clone $extension;
+        }
+    }
+
     public function runAll(Color $color, $method, $args)
     {
         $result = null;

--- a/src/SyHolloway/MrColor/FormatCollection.php
+++ b/src/SyHolloway/MrColor/FormatCollection.php
@@ -30,6 +30,17 @@ class FormatCollection
             $this->formats[] = clone $format;
         }
     }
+    
+    public function __clone()
+    {
+        $tmp = $this->formats;
+
+        $this->formats = array();
+
+        foreach ($tmp as $format) {
+            $this->formats[] = clone $format;
+        }
+    }
 
     public function update($key, $value, $currentHex)
     {


### PR DESCRIPTION
Noticed in the example.php file that after updating the hue to 300, both $color4 and color5 were updated. I added the __clone method to do a deep clone.
