### PR TITLE
- BUG: Color was not created correctly when only hsl color properties ar...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ pip-log.txt
 #sublimetext
 *.sublime-project
 *.sublime-workspace
+/nbproject/private/

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,20 @@
 {
-    "name": "syholloway/mrcolor",
+    "name": "dobby007/mrcolor",
     "type": "library",
-    "description": "Color manipulation tools and format conversion for PHP",
+    "description": "Color manipulation tools and format conversion for PHP. This is the fork of https://github.com/syholloway/mrcolor . The package name of the original library is 'syholloway/mrcolor'",
     "keywords": ["color", "manipulation", "format"],
-    "homepage": "https://github.com/syholloway/mrcolor",
+    "homepage": "https://github.com/Dobby007/mrcolor",
     "license": "MIT",
     "authors": [
         {
             "name": "Simon Holloway",
             "email": "holloway.sy@gmail.com",
             "homepage": "http://hollowaydesign.com/"
+        },
+        {
+            "name": "Alexander Gilevich",
+            "email": "alegil91@gmail.com",
+            "homepage": "http://flydigo.com"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "syholloway/mrcolor",
     "type": "library",
     "description": "Color manipulation tools and format conversion for PHP",
-    "keywords": [ "color", "manipulation", "format" ],
+    "keywords": ["color", "manipulation", "format"],
     "homepage": "https://github.com/syholloway/mrcolor",
     "license": "MIT",
     "authors": [
@@ -16,8 +16,8 @@
         "php": ">=5.3.0"
     },
     "autoload": {
-        "psr-0": { 
-        	"SyHolloway": "src/" 
+        "psr-0": {
+            "SyHolloway": "src/"
         }
-	}
+    }
 }

--- a/docs/example.php
+++ b/docs/example.php
@@ -68,6 +68,12 @@
                         'lightness' => 0.59
                     )
                 );
+                $color12->dump();
+                
+                echo '<h2>Update previous color with HSL values</h2>';
+                $color12->saturation = 0.7;
+                $color12->lightness += 0.2;
+                $color12->hue -= 20;
                 /*
                 $color12 = $color12->bulkUpdate(
                     array(

--- a/docs/example.php
+++ b/docs/example.php
@@ -58,6 +58,36 @@
                 );
 
                 $color2->dump();
+                
+                echo '<h2>Create color with HSL values</h2>';
+                //Create a color with HSL values
+                $color12 = Color::create(
+                    array(
+                        'hue' => 60,
+                        'saturation' => 0.48,
+                        'lightness' => 0.59
+                    )
+                );
+                /*
+                $color12 = $color12->bulkUpdate(
+                    array(
+                        'hue' => 60,
+                        'saturation' => 0.48,
+                        'lightness' => 0.59
+                    )
+                );
+                */
+                $color12->dump();
+                
+                echo '<h2>Create color with HEX value</h2>';
+                //Create a color with HSL values
+                $color13 = Color::create(
+                    array(
+                        'hex' => 'c8c864'
+                    )
+                );
+                
+                $color13->dump();
 
                 echo '<h2>Manipulating color with properties</h2>';
 
@@ -79,6 +109,8 @@
 
                 $color3->alpha++;
 
+                
+                
                 var_dump($color3->red);
 
                 $color3->dump();

--- a/manual-init.php
+++ b/manual-init.php
@@ -16,3 +16,4 @@ include($ex . 'Toolkit.php');
 include($ex . 'Formatter.php');
 include($fm . 'Rgb.php');
 include($fm . 'Hsl.php');
+include($fm . 'Hex.php');

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,0 +1,18 @@
+auxiliary.org-netbeans-modules-css-prep.less_2e_compiler_2e_options=
+auxiliary.org-netbeans-modules-css-prep.less_2e_enabled=false
+auxiliary.org-netbeans-modules-css-prep.less_2e_mappings=/less:/css
+auxiliary.org-netbeans-modules-css-prep.sass_2e_compiler_2e_options=
+auxiliary.org-netbeans-modules-css-prep.sass_2e_enabled=false
+auxiliary.org-netbeans-modules-css-prep.sass_2e_mappings=/scss:/css
+auxiliary.org-netbeans-modules-web-clientproject-api.js_2e_libs_2e_folder=js/libs
+browser.reload.on.save=true
+code.analysis.excludes=
+ignore.path=
+include.path=\
+    ${php.global.include.path}
+php.version=PHP_53
+source.encoding=UTF-8
+src.dir=.
+tags.asp=false
+tags.short=false
+web.root=.

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.php.project</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/php-project/1">
+            <name>mrcolor</name>
+        </data>
+    </configuration>
+</project>

--- a/src/SyHolloway/MrColor/Format/Hex.php
+++ b/src/SyHolloway/MrColor/Format/Hex.php
@@ -1,0 +1,45 @@
+<?php
+namespace SyHolloway\MrColor\Format;
+
+use SyHolloway\MrColor\Color;
+use SyHolloway\MrColor\Format;
+
+/**
+ * Hex format for MrColor. It's used only for internal purposes.
+ *
+ * @package MrColor
+ * @author Simon Holloway
+ */
+class Hex extends Format
+{
+    /**
+     * The current color in this format
+     *
+     * @var array
+     */
+    protected $values = array(
+        'hex' => 0
+    );
+
+    /**
+     * Return the corresponding hex color value for the value in this format
+     *
+     * @return string (6 characters, hex color value, no hash)
+     */
+    public function toHex()
+    {
+        return $this->values['hex'];
+    }
+
+    /**
+     * Load the given hex color value into this format
+     *
+     * @param string (6 characters, hex color value, no hash)
+     */
+    public function fromHex($hex)
+    {
+        $this->values = array(
+            'hex' => $hex
+        );
+    }
+}

--- a/src/SyHolloway/MrColor/Format/Hsl.php
+++ b/src/SyHolloway/MrColor/Format/Hsl.php
@@ -53,7 +53,7 @@ class Hsl extends Format
             dechex($g),
             dechex($b)
         );
-
+        
         //Make sure the hex is 6 digit
         foreach ($hex as $key => $value) {
             $hex[$key] = strlen($value) === 1 ? '0' . $value : $value ;

--- a/src/SyHolloway/MrColor/FormatCollection.php
+++ b/src/SyHolloway/MrColor/FormatCollection.php
@@ -4,6 +4,7 @@ namespace SyHolloway\MrColor;
 use SyHolloway\MrColor\Format;
 use SyHolloway\MrColor\Format\Rgb;
 use SyHolloway\MrColor\Format\Hsl;
+use SyHolloway\MrColor\Format\Hex;
 
 /**
  * Provides a collection manager for MrColor formats
@@ -44,15 +45,22 @@ class FormatCollection
 
     public function update($key, $value, $currentHex)
     {
+        $oldHex = $currentHex;
+        $foundFormat = false;
         foreach ($this->formats as $format) {
             if ($format->hasValue($key)) {
+                $foundFormat = $format;
                 $currentHex = $format->set($key, $value)->toHex();
                 break;
             }
         }
-
-        foreach ($this->formats as $format) {
-            $format->fromHex($currentHex);
+        
+        if ($foundFormat) {
+            foreach ($this->formats as $format) {
+                if ($format !== $foundFormat) {
+                    $format->fromHex($currentHex);
+                }
+            }
         }
 
         return $currentHex;
@@ -105,5 +113,6 @@ class FormatCollection
 
         self::registerDefaultFormat(new Rgb());
         self::registerDefaultFormat(new Hsl());
+        self::registerDefaultFormat(new Hex());
     }
 }


### PR DESCRIPTION
There were a few bugs in the "master" branch. At first, color was not created correctly when only hsl color properties are supplied. Because of RGB to HSL convert algorithm's nature, HSL properties "hue" and "saturation" are always equal to 0, even if you tell them not to. This is because lightness is 0. The output color will always be "#000" till you modify the lightness property. And consequently, the output color was wrong until now. You can check it with the following code:

> ```
>             $color12 = Color::create(
>                array(
>                    'hue' => 60,
>                    'saturation' => 0.48,
>                    'lightness' => 0.59
>                )
>            );
> ```

The correct result is: rgba(201, 201, 100, 1). 
Also there was a bug when color is supplied in a hex format. Properties were not updated. You can see it in your last example. I solved it by adding a "virtual" hex format. I think, that's all what I fixed...
